### PR TITLE
Force json to v 1.8.6 for local compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       concurrent-ruby (~> 1.1)
       countries (~> 3.0)
       faraday (~> 1.0)
-      json (~> 2.2)
+      json (~> 1.8.6)
       money (~> 6.13)
 
 GEM
@@ -29,7 +29,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
-    json (2.3.1)
+    json (1.8.6)
     method_source (1.0.0)
     minitest (5.14.1)
     money (6.13.8)


### PR DESCRIPTION
Do this for local Ripl compatibility. This may break non-Ripl users